### PR TITLE
Interval updates for version 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GaussSuppression
 Type: Package
 Title: Tabular Data Suppression using Gaussian Elimination
-Version: 0.9.6
-Date: 2025-03-12
+Version: 0.9.8
+Date: 2025-04-24
 Authors@R: c(person("Øyvind", "Langsrud", role = c("aut", "cre"),
                     email = "oyl@ssb.no",
                     comment = c(ORCID = "0000-0002-1380-4396")),
@@ -13,7 +13,7 @@ Authors@R: c(person("Øyvind", "Langsrud", role = c("aut", "cre"),
              person("Vidar Norstein", "Klungre", role = "rev",
                     comment = c(ORCID = "0000-0003-1925-5911")),
              person("Statistics Norway", role = "cph"))
-Imports: SSBtools (>= 1.7.0), RegSDC (>= 0.7.0), stats, methods, utils, Matrix
+Imports: SSBtools (>= 1.7.5), RegSDC (>= 0.7.0), stats, methods, utils, Matrix
 Description: A statistical disclosure control tool to protect tables by suppression 
     using the Gaussian elimination secondary suppression algorithm 
     (Langsrud, 2024) <doi:10.1007/978-3-031-69651-0_6>. A suggestion is 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## GaussSuppression	1.0.0
+* The package has been stable and in practical use for a long time. The release of version 1.0.0 is therefore appropriate.
+* Interval examples are now included in the vignettes.
+* Progress information during extra suppression to meet interval width requirements now counts down instead of up, making it easier to interpret.
+* Updated to support the latest 
+  [highs](https://CRAN.R-project.org/package=highs) 
+  version (1.9.0-1) for interval computation.
+* The warning about interval calculations being experimental has been removed.
+
 
 ## GaussSuppression	0.9.6
 * Misleading warnings in `SuppressionFromDecimals()` are now prevented.  

--- a/R/FixRiskyIntervals.R
+++ b/R/FixRiskyIntervals.R
@@ -34,7 +34,7 @@ FixRiskyIntervals <-
     if (!lpPackage %in% c("lpSolve", "Rsymphony", "Rglpk", "highs"))
       stop("Only 'lpSolve', 'Rsymphony' and 'Rglpk' solvers are supported.")
     
-    if (!require(lpPackage, character.only = TRUE,  quietly = TRUE)) {
+    if (!requireNamespace(lpPackage,  quietly = TRUE)) {
       stop(paste0("Package '", lpPackage, "' is not available."))
     }
     

--- a/R/FixRiskyIntervals.R
+++ b/R/FixRiskyIntervals.R
@@ -239,6 +239,8 @@ FixRiskyIntervals <-
     verboseFix <- TRUE
     nline <- 10
     
+    nz <- length(a$z)
+    
     for (k in seq_along(so)) {
       
       i <- abs(so[k])
@@ -253,7 +255,7 @@ FixRiskyIntervals <-
             nline <- 0
           }
           nline <- nline + 1
-          cat(i)
+          cat(nz + 1L - i)
         }
         # cat("----", i, "---------\n")
         
@@ -310,7 +312,7 @@ FixRiskyIntervals <-
           
           if (verboseFix) {
             # cat("\n=== ", i, " out of", length(a$z), "==  ", length(extra_suppressed), " new primary ====\n")
-            cat("\n  ",i, ": ", length(extra_suppressed), " new, ",  "(", adjust_precision(a$z[i]),  ") ",  sep ="")
+            cat("\n  ",nz + 1L - i, ": ", length(extra_suppressed), " new, ",  "(", adjust_precision(a$z[i]),  ") ",  sep ="")
             nline <- 0
           }
         }

--- a/R/GaussSuppressionFromData.R
+++ b/R/GaussSuppressionFromData.R
@@ -143,9 +143,6 @@
 #'        Intervals, `[lo_1, up_1]`, are intervals calculated prior to additional suppression.         
 #'    * **`rangePercent`:** Required interval width expressed as a percentage
 #'    * **`rangeMin`:** Minimum required width of the interval
-#'    
-#'                   Please note that interval calculations may have a 
-#'                   different interface in future versions.
 #'                                 
 #' @param aggregatePackage Package used to preAggregate/extraAggregate. 
 #'                         Parameter `pkg` to \code{\link[SSBtools]{aggregate_by_pkg}}.

--- a/R/GaussSuppressionFromData.R
+++ b/R/GaussSuppressionFromData.R
@@ -281,7 +281,7 @@ GaussSuppressionFromData = function(data, dimVar = NULL, freqVar=NULL,
     output <- "publish"
   } else {
     if (!is.null(lpPackage)) {
-      if (!require(lpPackage, character.only = TRUE, quietly = TRUE)) {
+      if (!requireNamespace(lpPackage, quietly = TRUE)) {
         stop(paste0("Package '", lpPackage, "' is not available."))
       }
       if (hasArg(rangePercent) | hasArg(rangeMin)) {

--- a/R/Intervals.R
+++ b/R/Intervals.R
@@ -4,8 +4,6 @@
 #'
 #' This function solves linear programs to determine interval boundaries
 #' for suppressed cells.
-#'
-#' This function is still experimental.
 #' 
 #' Default in for `bounds` parameter in `Rsymphony_solve_LP` and `Rglpk_solve_LP`: 
 #' _The default for each variable is a bound between 0 and `Inf`._

--- a/R/Intervals.R
+++ b/R/Intervals.R
@@ -365,6 +365,10 @@ highsVal <- function(max, obj, mat, dir, rhs, types) {
   
   maximum <- max
   
+  if(length(types) == 1){
+    types <- rep(types, length(L))
+  }
+  
   solution <- highs::highs_solve(
     Q = NULL,  
     L = L,

--- a/R/Intervals.R
+++ b/R/Intervals.R
@@ -54,7 +54,7 @@ ComputeIntervals <-
     if (!lpPackage %in% c("lpSolve", "Rsymphony", "Rglpk", "highs"))
       stop("Only 'lpSolve', 'Rsymphony' and 'Rglpk' solvers are supported.")
     
-    if (!require(lpPackage, character.only = TRUE,  quietly = TRUE)) {
+    if (!requireNamespace(lpPackage,  quietly = TRUE)) {
       stop(paste0("Package '", lpPackage, "' is not available."))
     }
     

--- a/R/PackageSpecs.R
+++ b/R/PackageSpecs.R
@@ -88,7 +88,7 @@ PackageSpecs <- function(x = NULL, printTable = FALSE) {
   )
   
   if (printTable) {
-    if (!require("knitr", character.only = TRUE, quietly = TRUE)) {
+    if (!requireNamespace("knitr", quietly = TRUE)) {
       message(paste0("Package '", "knitr", "' is not available."))
       return(NULL)
     }

--- a/R/PackageSpecs.R
+++ b/R/PackageSpecs.R
@@ -88,6 +88,10 @@ PackageSpecs <- function(x = NULL, printTable = FALSE) {
   )
   
   if (printTable) {
+    if (!require("knitr", character.only = TRUE, quietly = TRUE)) {
+      message(paste0("Package '", "knitr", "' is not available."))
+      return(NULL)
+    }
     rows <- unique(unlist(lapply(specList, names)))
     rows <- rows[rows != ""]
     pt <- NULL

--- a/man/ComputeIntervals.Rd
+++ b/man/ComputeIntervals.Rd
@@ -52,8 +52,6 @@ This function solves linear programs to determine interval boundaries
 for suppressed cells.
 }
 \details{
-This function is still experimental.
-
 Default in for \code{bounds} parameter in \code{Rsymphony_solve_LP} and \code{Rglpk_solve_LP}:
 \emph{The default for each variable is a bound between 0 and \code{Inf}.}
 Details in \code{lpSolve}: \emph{Note that every variable is assumed to be \verb{>= 0}!}

--- a/man/GaussSuppressionFromData.Rd
+++ b/man/GaussSuppressionFromData.Rd
@@ -173,10 +173,6 @@ Intervals, \verb{[lo_1, up_1]}, are intervals calculated prior to additional sup
 \itemize{
 \item \strong{\code{rangePercent}:} Required interval width expressed as a percentage
 \item \strong{\code{rangeMin}:} Minimum required width of the interval
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{         Please note that interval calculations may have a 
-         different interface in future versions.
-}\if{html}{\out{</div>}}
 }
 }}
 

--- a/tests/testthat/test-FixRiskyIntervals.R
+++ b/tests/testthat/test-FixRiskyIntervals.R
@@ -1,7 +1,7 @@
 test_that("FixRiskyIntervals", {
   lpPackage <- "Rglpk"
   skip_if_not_installed(lpPackage)
-  if (require(lpPackage, character.only = TRUE, quietly = TRUE)) {
+  if (requireNamespace(lpPackage, quietly = TRUE)) {
     z3 <- SSBtoolsData("z3")
     upper <- z3$region %in% LETTERS
     z3$region[upper] <- paste0(z3$region[upper], 2)

--- a/vignettes/GaussKable.R
+++ b/vignettes/GaussKable.R
@@ -130,9 +130,11 @@ G <- function(data, dimVar = NULL, freqVar = NULL,
               font_size = 14,   # Codes found in s will be ordered as in s
               s = c("young", "old", "Iceland", "Portugal", "Spain", "nonEU", "EU")) {
   
-  out <- fun(data = data, 
-             hierarchies = hierarchies, formula = formula, dimVar = dimVar, 
-             freqVar = freqVar, printInc = FALSE, ...)
+  
+  capture.output({
+    out <- fun(data = data, 
+               hierarchies = hierarchies, formula = formula, dimVar = dimVar, 
+               freqVar = freqVar, printInc = FALSE, ...)})
   dimVar <- NamesFromModelMatrixInput(data = data, 
                                       hierarchies = hierarchies, formula = formula, dimVar = dimVar, ...)
   dimVar <- dimVar[dimVar %in% names(out)]

--- a/vignettes/Magnitude_table_suppression.Rmd
+++ b/vignettes/Magnitude_table_suppression.Rmd
@@ -322,9 +322,50 @@ In Table 3, *Governmental:Total* and  *Industry:Total* are suppressed due to adv
 In fact, by using `singletonMethod = "none"`, all tables above will be suppressed differently.
 
 
+## Intervals
+
+Intervals for the primarily suppressed cells are computed whenever the `lpPackage` parameter is specified. 
+Additionally, if `rangePercent` and/or `rangeMin` are provided, further suppression is performed to ensure 
+that the interval width requirements are met. 
+See the documentation for the `lpPackage` parameter in `?GaussSuppressionFromData` for more details.
+
+In the example below, the interval widths for output lines 12, 14, 17, and 20 are 60.7, 
+which is too narrow since a minimum width of 80 is required. 
+Therefore, the cell on line 16 is additionally suppressed
 
 
+```{r, echo=FALSE, message=FALSE, warning=FALSE}
+if (!requireNamespace("Rglpk", quietly = TRUE)) {
+  cat("Note: The final part of this vignette requires the suggested package 'Rglpk', which is not installed. That part has been skipped.\n")
+  knitr::knit_exit()
+}
+```
 
 
+```{r}
+output <- SuppressDominantCells(data = dataset, 
+                                numVar = "value", 
+                                dimVar = c("geo", "sector2", "sector4"), 
+                                pPercent = 30, 
+                                rangePercent = 70, rangeMin = 80, 
+                                lpPackage = "Rglpk")
+output[c(12, 14, 16, 17, 20, 25), ] # some output lines 
+```
+\
 
+In the formatted output shown in Table 10 below, the final intervals are given in parentheses.
+
+\
+```{r echo=FALSE}
+P(caption = '**Table 10**: Output from `SuppressDominantCells`  with `pPercent = 30`, `rangePercent = 70`, `rangeMin = 80`, `lpPackage = "Rglpk"`',
+  data=dataset, 
+  numVar = "value", 
+  dimVar = c("geo", "sector2", "sector4"), 
+  pPercent = 30, 
+  rangePercent = 70, rangeMin = 80, 
+  lpPackage = "Rglpk",
+  fun = SuppressDominantCells, 
+  print_expr = 'ifelse(is.na(lo), value, paste0(value, " [", lo, ", ", up, "]"))')
+```
+\
 

--- a/vignettes/Small_count_frequency_table_suppression.Rmd
+++ b/vignettes/Small_count_frequency_table_suppression.Rmd
@@ -342,4 +342,49 @@ Then the sum of *young:2016:Iceland* and *young:2016:Portugal* can easily be cal
 Since zeros are never suppressed, the only possible values for these two cells are two ones.
 
 
+## Intervals
+
+Intervals for the primarily suppressed cells are computed whenever the `lpPackage` parameter is specified. 
+Additionally, if `rangePercent` and/or `rangeMin` are provided, further suppression is performed to ensure 
+that the interval width requirements are met. 
+See the documentation for the `lpPackage` parameter in `?GaussSuppressionFromData` for more details.
+
+
+In the example below, the interval widths are 4 after applying the standard Gaussian suppression algorithm. 
+Since a minimum width of 5 is required, the two cells for Spain are additionally suppressed.
+
+
+```{r, echo=FALSE, message=FALSE, warning=FALSE}
+if (!requireNamespace("Rglpk", quietly = TRUE)) {
+  cat("Note: The final part of this vignette requires the suggested package 'Rglpk', which is not installed. That part has been skipped.\n")
+  knitr::knit_exit()
+}
+```
+
+```{r}
+output <- SuppressSmallCounts(data = dataset, 
+                              formula = ~age*geo,  
+                              freqVar = "freq", 
+                              maxN = 3, 
+                              rangeMin = 5,
+                              lpPackage = "Rglpk")
+tail(output) 
+```
+\
+
+In the formatted output shown in Table 9 below, the final intervals are given in parentheses.
+
+\
+ <p style="text-align: center;"> <font size = 3> **Table 9**: Output from `SuppressSmallCounts`  with `formula = ~age*geo`, `maxN = 3`, `rangeMin = 5`, `lpPackage = "Rglpk"` </font> </p>
+```{r echo=FALSE}
+P(data=dataset, 
+  formula = ~age*geo,  
+  freqVar = "freq", 
+  maxN = 3, 
+  rangeMin = 5,
+  lpPackage = "Rglpk",
+  print_expr = 'ifelse(is.na(lo), freq, paste0(freq, " [", lo, ", ", up, "]"))')
+```
+\
+
 


### PR DESCRIPTION
and interval examples in the vignettes

as described in NEWS

In addition, use `requireNamespace()` for suggested packages (instead of `require()`) to comply with CRAN policies.