### PR TITLE
Documentation on aggregateNA argument expanded

### DIFF
--- a/R/GaussSuppressionFromData.R
+++ b/R/GaussSuppressionFromData.R
@@ -151,7 +151,13 @@
 #' @param aggregatePackage Package used to preAggregate/extraAggregate. 
 #'                         Parameter `pkg` to \code{\link[SSBtools]{aggregate_by_pkg}}.
 #' @param aggregateNA Whether to include NAs in the grouping variables while preAggregate/extraAggregate. 
-#'                    Parameter `include_na` to \code{\link[SSBtools]{aggregate_by_pkg}}.
+#'                    Parameter `include_na` to \code{\link[SSBtools]{aggregate_by_pkg}}. 
+#'                    NAs will not be present in the output table's dimensions even if `aggregateNA = FALSE`.
+#'                    When using the formula interface, this is controlled by the `NAomit` parameter (default `TRUE`),
+#'                    which is passed to the function `SSBtools::Formula2ModelMatrix()`.
+#'                    Note that under normal circumstances NAs should never be present in the grouping variables.
+#'                    As such, if NAs are present in the grouping variables, using the `dimVar` or `hierarchies` interfaces 
+#'                    will result in errors.
 #' @param aggregateBaseOrder Parameter `base_order` to \code{\link[SSBtools]{aggregate_by_pkg}},
 #'                           used when preAggregate/extraAggregate. 
 #'                           The parameter does not affect the ordering of ordinary output. 

--- a/man/GaussSuppressionFromData.Rd
+++ b/man/GaussSuppressionFromData.Rd
@@ -187,7 +187,13 @@ Intervals, \verb{[lo_1, up_1]}, are intervals calculated prior to additional sup
 Parameter \code{pkg} to \code{\link[SSBtools]{aggregate_by_pkg}}.}
 
 \item{aggregateNA}{Whether to include NAs in the grouping variables while preAggregate/extraAggregate.
-Parameter \code{include_na} to \code{\link[SSBtools]{aggregate_by_pkg}}.}
+Parameter \code{include_na} to \code{\link[SSBtools]{aggregate_by_pkg}}.
+NAs will not be present in the output table's dimensions even if \code{aggregateNA = FALSE}.
+When using the formula interface, this is controlled by the \code{NAomit} parameter (default \code{TRUE}),
+which is passed to the function \code{SSBtools::Formula2ModelMatrix()}.
+Note that under normal circumstances NAs should never be present in the grouping variables.
+As such, if NAs are present in the grouping variables, using the \code{dimVar} or \code{hierarchies} interfaces
+will result in errors.}
 
 \item{aggregateBaseOrder}{Parameter \code{base_order} to \code{\link[SSBtools]{aggregate_by_pkg}},
 used when preAggregate/extraAggregate.


### PR DESCRIPTION
Small changes to documentation of the `aggregateNA` argument to the `GaussSuppressionFromData` function. 

This includes a reference to the `NAomit` parameter of the `SSBtools` function and also explains how NAs in the grouping variables work. This amends the issues with documentation mentioned in #119.

I am agnostic about whether better error handling is needed for this issue. In my opinion it can equally well be left as-is since normal usage would never involve NAs in the classifying variables. 